### PR TITLE
Standardise Renovate config to shared TryGhost default preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "@tryghost:base"
-  ]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>TryGhost/renovate-config"],
+}


### PR DESCRIPTION
## What

Standardise this repo's Renovate config on the shared TryGhost preset.

- **Preset applied:** `local>TryGhost/renovate-config` (the shared `default` preset).
- **Config location:** `renovate.json` → `renovate.json5` (migrated; old file removed).
- **`package.json` `renovate` key:** none existed — no removal needed.

## Why

The config extended the legacy npm-style `@tryghost:base` shareable preset, which is no longer the standardised reference across TryGhost repos. Pointing it at the shared `local>TryGhost/renovate-config` preset keeps this repo on the same Renovate policy (grouping, scheduling, automerge behaviour) as the rest of the org, managed centrally in [TryGhost/renovate-config](https://github.com/TryGhost/renovate-config). The file is migrated to `renovate.json5` with the `$schema` reference to match the shared-config convention.

## Overrides

- **Dropped:** `extends: ["@tryghost:base"]` — replaced by the shared `default` preset reference. This was the only content in the file; there were no `automerge`, `schedule`, `timezone`, `packageRules`, host/auth, or manager overrides to preserve.

## Verification

- `renovate-config-validator renovate.json5` → **Config validated successfully**.
- JSON5 parses; `renovate.json` removed so there is a single config source.

ref [GVA-795](https://linear.app/ghost/issue/GVA-795/clean-repos-deploy)
