### PR TITLE
Add e2e coverage for the npm install path

### DIFF
--- a/test/e2e/deploy.test.js
+++ b/test/e2e/deploy.test.js
@@ -7,10 +7,10 @@ function remote(cmd) {
     return execSync('ssh deploy@target "' + cmd + '"', {encoding: 'utf8'}).trim();
 }
 
-function runDeploy() {
+function runDeploy(configOverrides) {
     return new Promise(function (resolve, reject) {
         const shipit = new Shipit({environment: 'production'});
-        require('./fixtures/shipitfile')(shipit);
+        require('./fixtures/shipitfile')(shipit, configOverrides);
         shipit.initialize();
         shipit.start('deploy', function (err) {
             if (err) {
@@ -136,5 +136,38 @@ describe('Deploy', function () {
         it('keeps the current symlink valid', function () {
             remote('test -d ' + DEPLOY_TO + '/current');
         });
+    });
+});
+
+// The deploy runtime picks the package manager from shipit.config.npm:
+// `npm install` when true, `yarn install` (the default) otherwise — see
+// lib/deploy.js. The suite above exercises the default yarn branch end to
+// end; this one proves the npm branch actually installs on a real target,
+// so a dependency bump or runtime change that breaks it fails CI instead of
+// being silently auto-merged.
+describe('Deploy with npm (shipit.config.npm = true)', function () {
+    // Under the deploy user's own home so it can be created without the extra
+    // /opt provisioning the default-path deployTo gets in the target image.
+    const NPM_DEPLOY_TO = '/home/deploy/deploy_to_npm';
+
+    beforeAll(async function () {
+        // Isolated deployTo so this does not disturb the default-path deploy.
+        remote('mkdir -p ' + NPM_DEPLOY_TO + '/shared && touch ' + NPM_DEPLOY_TO + '/shared/config.production.json');
+
+        process.env.NO_RESTART = 'false';
+        await runDeploy({npm: true, deployTo: NPM_DEPLOY_TO});
+    });
+
+    it('installs lodash so the deployed app can resolve it', function () {
+        // Asserted via current/ rather than shared/: npm (unlike yarn) replaces
+        // the symlinked node_modules with a real directory in the release, so
+        // the shared-dir optimisation does not apply to the npm path. What
+        // matters is that the dependency is resolvable from the deployed app.
+        remote('test -d ' + NPM_DEPLOY_TO + '/current/node_modules/lodash');
+    });
+
+    it('runs npm rather than yarn (writes package-lock.json, no yarn.lock)', function () {
+        remote('test -f ' + NPM_DEPLOY_TO + '/current/package-lock.json');
+        remote('test ! -f ' + NPM_DEPLOY_TO + '/current/yarn.lock');
     });
 });

--- a/test/e2e/fixtures/shipitfile.js
+++ b/test/e2e/fixtures/shipitfile.js
@@ -1,10 +1,10 @@
 const deploy = require('/app/index.js');
 
-module.exports = function (shipit) {
+module.exports = function (shipit, configOverrides = {}) {
     deploy(shipit);
 
     shipit.initConfig({
-        default: {
+        default: Object.assign({
             workspace: '/app/test/e2e/fixtures/test-project',
             deployTo: '/opt/deploy_to',
             ignores: ['.git', 'node_modules'],
@@ -15,7 +15,7 @@ module.exports = function (shipit) {
                 name: 'config.production.json',
                 type: 'file'
             }]
-        },
+        }, configOverrides),
         production: {
             servers: deploy.getServerList()
         }


### PR DESCRIPTION
## What

Adds end-to-end coverage for the **`npm install` runtime branch**, which until now was only asserted as a command string in a unit test.

- New e2e suite *"Deploy with npm (`shipit.config.npm = true`)"* deploys with `npm: true` to an isolated `deployTo` and asserts:
  - npm genuinely ran — `package-lock.json` is written and no `yarn.lock` is present;
  - the dependency (`lodash`) is resolvable from the deployed app (`current/node_modules/lodash`).
- The shipit test fixture now takes per-deploy config overrides so both package managers run from the same harness.

## Why

CI is the gate that makes **Renovate auto-merge safe** (this repo is `ci_trust: high` and uses the `default` preset, which auto-merges majors). [lib/deploy.js](https://github.com/TryGhost/Deploy/blob/main/lib/deploy.js#L31) picks `npm install` vs `yarn install` from `shipit.config.npm`, but only the yarn branch was exercised against a real target. A dependency bump or runtime change that broke the npm path would have passed CI and auto-merged unnoticed. Now both install branches are proven end-to-end.

## Notes

- **Documented behavioural difference:** npm (unlike yarn) replaces the symlinked `node_modules` with a real directory in the release, so the `shared/node_modules` optimisation does not apply to the npm path. The test asserts the dep is reachable from `current/` rather than `shared/` to reflect this.
- The npm deploy targets `/home/deploy/deploy_to_npm` (the deploy user's home) so no extra `/opt` provisioning is needed in the e2e target image.
- Runtime code is unchanged — this is test-only.

## Verification

- Full docker e2e suite: **19/19 pass** (17 existing + 2 new) on the Node 20 runner.
- `pnpm lint` and `pnpm test:unit` (8 tests, 100% coverage) pass.

ref [GVA-795](https://linear.app/ghost/issue/GVA-795/clean-repos-deploy)
