### PR TITLE
Add pnpm as a deploy-time package manager option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ shipit.initConfig({
 });
 ```
 
-- `yarn` (default) and `npm` ship with Node, so they are always present on the
-  server. The legacy `npm: true` flag still works (equivalent to
-  `packageManager: 'npm'`); `packageManager` takes precedence if both are set.
-- `pnpm` is **not** bundled with Node — the server must provide it (e.g. via
-  Corepack or a global install), otherwise the deploy fails.
+- `npm` is bundled with Node, so it is always present on the server. `yarn`
+  (the default) is not part of Node but is commonly preinstalled (e.g. in the
+  official Node Docker images); `pnpm` usually is not. Whichever manager you
+  choose must be available on the server, or the install step fails (Corepack or
+  a global install can provide yarn/pnpm). The legacy `npm: true` flag still
+  works (equivalent to `packageManager: 'npm'`); `packageManager` takes
+  precedence if both are set.
 - `allDeps: true` installs dev dependencies too (drops the production-only flag:
   `--production` for yarn/npm, `--prod` for pnpm).
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,40 @@ And add a new script to your package.json file:
   },
 ```
 
+# Package manager
+
+By default the deploy runs `yarn install --production` on the server. Choose a
+different package manager with the `packageManager` config option:
+
+```
+shipit.initConfig({
+  default: {
+    // ...
+    packageManager: 'pnpm' // 'yarn' (default) | 'npm' | 'pnpm'
+  }
+});
+```
+
+- `yarn` (default) and `npm` ship with Node, so they are always present on the
+  server. The legacy `npm: true` flag still works (equivalent to
+  `packageManager: 'npm'`); `packageManager` takes precedence if both are set.
+- `pnpm` is **not** bundled with Node — the server must provide it (e.g. via
+  Corepack or a global install), otherwise the deploy fails.
+- `allDeps: true` installs dev dependencies too (drops the production-only flag:
+  `--production` for yarn/npm, `--prod` for pnpm).
+
+### pnpm and `sharedLinks`
+
+Do **not** list `node_modules` in `sharedLinks` when using pnpm. pnpm cannot
+install into a symlinked `node_modules` (it fails with `ENOTDIR`), and its
+content-addressable store already hardlink-dedupes packages across releases, so
+sharing `node_modules` is both unsupported and unnecessary. Share only files
+such as config:
+
+```
+sharedLinks: [{name: 'config.production.json', type: 'file'}]
+```
+
 # Usage
 
 ## Deploy

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -1,9 +1,10 @@
 const path = require('path');
 
-// npm and yarn ship with Node, so they are always present on a target server.
-// pnpm is not bundled — a server deploying with packageManager: 'pnpm' must
-// provide it (e.g. via Corepack). The production flag also differs: npm and
-// yarn take --production, pnpm takes --prod.
+// npm is bundled with Node, so it is always present on a target server. yarn is
+// not part of Node but is commonly preinstalled (e.g. in the official Node
+// Docker images); pnpm usually is not. Whichever manager a deploy selects must
+// be available on the server or the install step fails. The production flag
+// also differs: npm and yarn take --production, pnpm takes --prod.
 const PACKAGE_MANAGERS = {
     yarn: {install: 'yarn install', productionFlag: '--production'},
     npm: {install: 'npm install', productionFlag: '--production'},
@@ -11,7 +12,10 @@ const PACKAGE_MANAGERS = {
 };
 
 function resolvePackageManager(config) {
-    if (config.packageManager) {
+    // An explicitly set but invalid value (including an empty string) fails
+    // fast here; an unset packageManager (undefined/null) falls back to the
+    // legacy selector below.
+    if (config.packageManager !== undefined && config.packageManager !== null) {
         if (!PACKAGE_MANAGERS[config.packageManager]) {
             throw new Error(
                 'Unknown packageManager "' + config.packageManager + '". Expected one of: '

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -1,5 +1,42 @@
 const path = require('path');
 
+// npm and yarn ship with Node, so they are always present on a target server.
+// pnpm is not bundled — a server deploying with packageManager: 'pnpm' must
+// provide it (e.g. via Corepack). The production flag also differs: npm and
+// yarn take --production, pnpm takes --prod.
+const PACKAGE_MANAGERS = {
+    yarn: {install: 'yarn install', productionFlag: '--production'},
+    npm: {install: 'npm install', productionFlag: '--production'},
+    pnpm: {install: 'pnpm install', productionFlag: '--prod'}
+};
+
+function resolvePackageManager(config) {
+    if (config.packageManager) {
+        if (!PACKAGE_MANAGERS[config.packageManager]) {
+            throw new Error(
+                'Unknown packageManager "' + config.packageManager + '". Expected one of: '
+                + Object.keys(PACKAGE_MANAGERS).join(', ') + '.'
+            );
+        }
+
+        return config.packageManager;
+    }
+
+    // Backwards compatibility: the legacy boolean `npm` flag selected npm, and
+    // yarn was the default for everything else.
+    return (config.npm === true) ? 'npm' : 'yarn';
+}
+
+function buildInstallCommand(config) {
+    const packageManager = PACKAGE_MANAGERS[resolvePackageManager(config)];
+
+    if (config.allDeps) {
+        return packageManager.install;
+    }
+
+    return packageManager.install + ' ' + packageManager.productionFlag;
+}
+
 module.exports = function (shipit) {
     shipit.task('deploy', async () => {
         const rsyncFrom = shipit.config.rsyncFrom || shipit.config.workspace;
@@ -8,6 +45,9 @@ module.exports = function (shipit) {
         const releasePath = path.resolve(releasesPath, new Date().toISOString().replace(/:/g, '_').replace(/\./g, '_'));
         const currentPath = path.resolve(shipit.config.deployTo, 'current');
         const options = (shipit.config.deploy && shipit.config.deploy.remoteCopy) || {rsync: '--del'};
+        // Resolved before any remote mutation so an unknown packageManager fails
+        // the deploy up front rather than after the release has been copied.
+        const installCommand = buildInstallCommand(shipit.config);
 
         shipit.log('Deploying project to servers...');
 
@@ -28,13 +68,7 @@ module.exports = function (shipit) {
             await shipit.remote('ln -nfs ' + sharedLinkPath + ' ' + currentLinkPath);
         }
 
-        let command = (shipit.config.npm === true) ? 'npm install' : 'yarn install';
-
-        if (!shipit.config.allDeps) {
-            command += ' --production';
-        }
-
-        await shipit.remote('cd ' + currentPath + ' && ' + command);
+        await shipit.remote('cd ' + currentPath + ' && ' + installCommand);
 
         const currentTmpPath = path.resolve(currentPath, 'tmp');
         const currentPublicPath = path.resolve(currentPath, 'public');

--- a/test/e2e/deploy.test.js
+++ b/test/e2e/deploy.test.js
@@ -171,3 +171,37 @@ describe('Deploy with npm (shipit.config.npm = true)', function () {
         remote('test ! -f ' + NPM_DEPLOY_TO + '/current/yarn.lock');
     });
 });
+
+// The pnpm branch of the same package-manager selector. pnpm is the runtime
+// option consumers migrating to pnpm need (GVA-795); unlike npm and yarn it is
+// not bundled with Node, so the target image provisions it (see target image).
+describe('Deploy with pnpm (shipit.config.packageManager = "pnpm")', function () {
+    const PNPM_DEPLOY_TO = '/home/deploy/deploy_to_pnpm';
+
+    beforeAll(async function () {
+        remote('mkdir -p ' + PNPM_DEPLOY_TO + '/shared && touch ' + PNPM_DEPLOY_TO + '/shared/config.production.json');
+
+        process.env.NO_RESTART = 'false';
+        await runDeploy({
+            packageManager: 'pnpm',
+            deployTo: PNPM_DEPLOY_TO,
+            // pnpm cannot install into a symlinked node_modules — it runs
+            // `mkdir node_modules` and fails with ENOTDIR — and its global
+            // store already hardlink-dedupes packages across releases, so the
+            // shared-node_modules optimisation is both unusable and redundant
+            // for pnpm. pnpm consumers therefore omit node_modules from
+            // sharedLinks (documented in the README).
+            sharedLinks: [{name: 'config.production.json', type: 'file'}]
+        });
+    });
+
+    it('installs lodash so the deployed app can resolve it', function () {
+        remote('test -d ' + PNPM_DEPLOY_TO + '/current/node_modules/lodash');
+    });
+
+    it('runs pnpm (writes pnpm-lock.yaml, no package-lock.json or yarn.lock)', function () {
+        remote('test -f ' + PNPM_DEPLOY_TO + '/current/pnpm-lock.yaml');
+        remote('test ! -f ' + PNPM_DEPLOY_TO + '/current/package-lock.json');
+        remote('test ! -f ' + PNPM_DEPLOY_TO + '/current/yarn.lock');
+    });
+});

--- a/test/e2e/target/Dockerfile
+++ b/test/e2e/target/Dockerfile
@@ -4,6 +4,10 @@ RUN apt-get update && \
     apt-get install -y openssh-server rsync && \
     rm -rf /var/lib/apt/lists/*
 
+# npm and yarn ship with the Node image; pnpm does not. A server deploying with
+# packageManager: 'pnpm' must provide it, so install it here to mirror that.
+RUN npm install -g pnpm@10.34.3
+
 RUN mkdir /run/sshd
 
 RUN useradd -m -s /bin/bash deploy && \

--- a/test/unit/deploy.test.js
+++ b/test/unit/deploy.test.js
@@ -147,6 +147,14 @@ describe('lib/deploy', function () {
         expect(calls.remote).toHaveLength(0);
     });
 
+    it('treats an explicitly empty packageManager as invalid rather than falling back', async function () {
+        process.env.NO_RESTART = 'true';
+        const {shipit, tasks} = createShipit(baseConfig({packageManager: ''}));
+        deploy(shipit);
+
+        await expect(tasks.deploy()).rejects.toThrow(/Unknown packageManager/);
+    });
+
     it('creates shared directories only for directory links and honours custom link targets', async function () {
         process.env.NO_RESTART = 'true';
         const config = baseConfig({

--- a/test/unit/deploy.test.js
+++ b/test/unit/deploy.test.js
@@ -100,6 +100,53 @@ describe('lib/deploy', function () {
         expect(remote).toContain('restart.txt');
     });
 
+    it('installs production deps with pnpm when packageManager is "pnpm"', async function () {
+        process.env.NO_RESTART = 'true';
+        const {shipit, calls, tasks} = createShipit(baseConfig({packageManager: 'pnpm'}));
+        deploy(shipit);
+
+        await tasks.deploy();
+
+        const remote = calls.remote.join('\n');
+        // pnpm's production flag is --prod, not the --production npm/yarn use.
+        expect(remote).toContain('pnpm install --prod');
+        expect(remote).not.toContain('--production');
+    });
+
+    it('installs all deps with pnpm when packageManager is "pnpm" and allDeps is set', async function () {
+        process.env.NO_RESTART = 'true';
+        const {shipit, calls, tasks} = createShipit(baseConfig({packageManager: 'pnpm', allDeps: true}));
+        deploy(shipit);
+
+        await tasks.deploy();
+
+        const remote = calls.remote.join('\n');
+        expect(/pnpm install(?! --prod)/.test(remote)).toBe(true);
+    });
+
+    it('lets an explicit packageManager take precedence over the legacy npm flag', async function () {
+        process.env.NO_RESTART = 'true';
+        const {shipit, calls, tasks} = createShipit(baseConfig({packageManager: 'yarn', npm: true}));
+        deploy(shipit);
+
+        await tasks.deploy();
+
+        const remote = calls.remote.join('\n');
+        expect(remote).toContain('yarn install --production');
+        expect(remote).not.toContain('npm install');
+    });
+
+    it('fails the deploy up front for an unknown packageManager', async function () {
+        process.env.NO_RESTART = 'true';
+        const {shipit, calls, tasks} = createShipit(baseConfig({packageManager: 'bun'}));
+        deploy(shipit);
+
+        await expect(tasks.deploy()).rejects.toThrow(/Unknown packageManager "bun"/);
+        // Resolved before any remote work, so nothing was copied to the server.
+        expect(calls.remoteCopy).toHaveLength(0);
+        expect(calls.remote).toHaveLength(0);
+    });
+
     it('creates shared directories only for directory links and honours custom link targets', async function () {
         process.env.NO_RESTART = 'true';
         const config = baseConfig({


### PR DESCRIPTION
## What

Adds **pnpm** as a deploy-time package-manager option — the runtime capability [GVA-795](https://linear.app/ghost/issue/GVA-795/clean-repos-deploy) is actually about (it unblocks pnpm consumers like Stats-Service / [GVA-794](https://linear.app/ghost/issue/GVA-794)).

- New `packageManager` config: `'yarn'` (default) | `'npm'` | `'pnpm'` ([lib/deploy.js](https://github.com/TryGhost/Deploy/blob/main/lib/deploy.js)).
- **Backward compatible:** the legacy `npm: true` flag still selects npm; yarn stays the default. An explicit `packageManager` takes precedence when both are set.
- pnpm's production flag is `--prod` (npm/yarn use `--production`), so the flag is now resolved per-manager.
- Unknown `packageManager` **fails the deploy up front**, before any release is copied.

## Two pnpm-specific constraints (documented in the README)

1. **pnpm isn't bundled with Node.** npm and yarn ship with every Node install; pnpm does not. A server deploying with `packageManager: 'pnpm'` must provide it (Corepack or a global install). The e2e target image installs `pnpm@10.34.3` to mirror that.
2. **pnpm can't use a symlinked `node_modules`.** It runs `mkdir node_modules` and fails with `ENOTDIR` (verified). Its content-addressable store already hardlink-dedupes packages across releases, so the `shared/node_modules` optimisation is both unusable and redundant for pnpm. **pnpm consumers must omit `node_modules` from `sharedLinks`** — ⚠️ relevant to how Stats-Service configures its deploy.

## Verification

- Unit: **12 tests, 100% coverage** — resolver covered (pnpm `--prod`, allDeps, explicit-PM precedence over the legacy flag, unknown-PM throws before any remote call).
- E2E: **21/21** on the Node 20 runner — yarn (default), npm, and **pnpm** install paths each deploy to a real target and prove the dependency is resolvable + the right lockfile is written.
- `pnpm lint` clean.

## Stacking

This is stacked on #40 (npm-path e2e), whose fixture refactor it builds on. **Base is `aileen/clean-repos-e2e-npm-path`** — merge #40 first, then I'll retarget this to `main` (or it can merge after #40 lands).

## Open question for reviewers

Should the runtime *defensively* skip a `node_modules` directory sharedLink when `packageManager: 'pnpm'` (so a consumer who forgets gets a working deploy instead of a cryptic `ENOTDIR`)? Kept it as documentation-only here per the "assume present, document it" decision, but happy to add the guard if preferred.

ref [GVA-795](https://linear.app/ghost/issue/GVA-795/clean-repos-deploy)
