### PR TITLE
Refresh README and add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md
+
+`@tryghost/deploy` is a [Shipit](https://github.com/shipitjs/shipit) plugin that
+deploys internal Ghost projects to servers over SSH. CommonJS Node, pnpm,
+Vitest. See `README.md` for what it does and how consumers use it.
+
+## Commands
+
+```sh
+pnpm install              # uses the pinned pnpm (packageManager field) via Corepack
+pnpm lint                 # oxlint + oxfmt --check
+pnpm lint:fix             # oxlint --fix + oxfmt
+pnpm test                 # lint + unit
+pnpm test:unit            # Vitest unit suite, with coverage (gated >=80%)
+pnpm test:e2e             # full deploy against throwaway Docker containers
+```
+
+## Boundaries — do not break these
+
+- **`lib/deploy.js` is a runtime contract, not just this repo's tooling.** It
+  shells the dependency install command (`yarn` / `npm` / `pnpm install`) on the
+  **remote** servers it deploys to, chosen from `shipit.config`. Jenkins-deployed
+  services depend on this exact behaviour. Don't "modernise" or change it; the
+  unit tests (`yarn install --production`, `npm install`) and the e2e
+  `installs lodash` tests exist to pin it. This is separate from how _this_ repo
+  builds itself (which is pnpm).
+- **Node 20.20.0, 22, and 24 must all keep working.** 20.20.0 is the floor, not
+  a guess: the consumers deployed by this tool — `daisy.js`, `zuul`,
+  `stats-service`, and the other Jenkins-deployed services — run on Node 20.20.0
+  on the core server, so the plugin has to keep working on that exact runtime.
+  It's encoded in `engines`, `.nvmrc`, and the CI matrix (which also covers 22
+  and 24 for headroom). **pnpm is pinned to the 10.x line** (`packageManager`) on
+  purpose — pnpm 11 requires Node >= 22.13 and would break the 20.20.0 leg. Don't
+  bump it to 11 until the core server moves off Node 20.
+- **GitHub Actions must be pinned to full commit SHAs** (org policy rejects
+  floating tags — every job fails in seconds otherwise). Keep the `# vX.Y.Z`
+  comment next to each SHA.
+
+## Gotchas
+
+- **e2e needs Docker running.** It builds two containers: a `runner` (installs
+  _this_ repo's deps with pnpm and runs Vitest) and a `target` (the deploy
+  destination — it has npm, yarn, and pnpm available so all three runtime install
+  paths can be exercised). No Docker → `pnpm test:e2e` can't run.
+- **The required status check is `All tests pass`** — an aggregator job that
+  `needs: [lint, test, e2e]`. Add new required jobs to its `needs`, not to branch
+  protection.
+- **pnpm consumers must not share `node_modules`.** pnpm can't install into a
+  symlinked `node_modules` (`ENOTDIR`); see the README's pnpm/`sharedLinks` note.
+
+## Publishing
+
+`pnpm ship` runs the tests then `pnpm publish && git push --follow-tags`. Unlike
+the old `yarn publish`, `pnpm publish` does **not** bump the version — run
+`pnpm version <patch|minor|major>` first (it writes the tag), then `pnpm ship`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@ Set of deployment tasks for Shipit in combination with internal Ghost projects.
 
 Install this package:
 
-`npm install @tryghost/deploy --save`
+`npm install @tryghost/deploy` (or `yarn add` / `pnpm add`)
+
+> Requires Node.js >= 20.20.0. The services this tool deploys (`daisy.js`,
+> `zuul`, `stats-service`, and other Jenkins-deployed projects) run on Node
+> 20.20.0 on the core server, so that is the minimum runtime the plugin keeps
+> working on; CI also tests 22 and 24.
 
 Add a `shipitfile.js` config with the following content. Keep in mind that it is never a good idea to commit private credentials to git. Private settings could for example be provided by using environment variables (`process.env.ENV_VARIABLE`).
 
 ```
 function init(shipit) {
-  require('ghost-deploy')(shipit);
+  require('@tryghost/deploy')(shipit);
 
   shipit.initConfig({
     default: {
@@ -87,11 +92,14 @@ sharedLinks: [{name: 'config.production.json', type: 'file'}]
 
 ## Deploy
 
-To deploy a project to the server configured as staging execute the following command:
-
-`yarn deploy <environment>`
+To deploy a project to a configured environment, run the `deploy` script with your
+package manager — `yarn deploy <environment>`, `npm run deploy <environment>`, or
+`pnpm run deploy <environment>`.
 
 Example: `yarn deploy staging`
+
+> With pnpm, use `pnpm run deploy`, not `pnpm deploy` — the latter is a built-in
+> pnpm command and will not run your script.
 
 ## Custom Tasks
 
@@ -99,7 +107,7 @@ If you need special tasks within your project it is possible to add new task in 
 
 ```
 function init(shipit) {
-  require('ghost-deploy')(shipit);
+  require('@tryghost/deploy')(shipit);
 
   ...
 
@@ -111,13 +119,9 @@ function init(shipit) {
 module.exports = init;
 ```
 
-You would then execute this task using
-
-`yarn deploy <environment> <task>`
-
-E.g.
-
-`yarn deploy staging pwd`
+You would then execute this task by passing its name as an argument, e.g.
+`yarn deploy staging pwd` (or `npm run deploy staging pwd` /
+`pnpm run deploy staging pwd`).
 
 (Note: deploy is the default task, so by default you don't have to provide a task)
 
@@ -158,4 +162,4 @@ Use cases for events are for example database migrations that are executed after
 
 # Copyright & License
 
-Copyright (c) 2013-2023 Ghost Foundation - Released under the [MIT license](LICENSE). Ghost and the Ghost Logo are trademarks of Ghost Foundation Ltd. Please see our [trademark policy](https://ghost.org/trademark/) for info on acceptable usage.
+Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](LICENSE). Ghost and the Ghost Logo are trademarks of Ghost Foundation Ltd. Please see our [trademark policy](https://ghost.org/trademark/) for info on acceptable usage.


### PR DESCRIPTION
## What

Docs cleanup (final clean-repos gate for this repo).

**README**
- Fix the stale `ghost-deploy` package name → `@tryghost/deploy` in the config samples.
- Make the deploy invocation **package-manager-agnostic** and warn about the real footgun: **`pnpm deploy` is a built-in pnpm command**, so pnpm users must run `pnpm run deploy` or pnpm intercepts it and the `deploy` script never runs.
- Generalise the install line; bump copyright `2013-2023` → `2013-2026`.
- (The "Package manager" section and `pnpm lint` commands were already corrected in the pnpm/oxlint PRs.)

**AGENTS.md (new) + `CLAUDE.md` symlink**
Captures the non-inferable operational facts an agent would otherwise break:
- `lib/deploy.js` is a **remote-install contract** (shells yarn/npm/pnpm on the servers it deploys to) — not this repo's own tooling; don't "modernise" it.
- Node **20.20.0/22/24** support window, and why **pnpm is pinned to 10.x** (pnpm 11 needs Node ≥ 22.13).
- SHA-pinned-actions org policy; the Docker two-container e2e (runner = pnpm/Vitest, target = has all three managers); the `All tests pass` required check; the `pnpm version` → `pnpm ship` release flow.

## Verification

- `pnpm lint` (oxlint + `oxfmt --check`, incl. the markdown) clean.
- `pnpm test:unit` — 13 tests, 100% coverage. Docs-only change; runtime untouched.
- `CLAUDE.md` committed as a symlink to `AGENTS.md` (mode 120000).

The GitHub repo **description** is being updated separately (`gh repo edit`), not in this PR.

ref [GVA-795](https://linear.app/ghost/issue/GVA-795/clean-repos-deploy)
