### PR TITLE
Run oxlint with --quiet in the lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "rm -rf dist && tsc",
     "typecheck": "tsc --noEmit",
-    "lint": "oxlint && oxfmt --check .",
+    "lint": "oxlint --quiet && oxfmt --check .",
     "lint:fix": "oxlint --fix && oxfmt .",
     "format": "oxfmt .",
     "test:unit": "vitest run --coverage",


### PR DESCRIPTION
## What

Adds `--quiet` to the `oxlint` invocation in the `lint` script:

```diff
- "lint": "oxlint && oxfmt --check .",
+ "lint": "oxlint --quiet && oxfmt --check .",
```

## Why

Per the updated Clean Repos oxlint baseline, oxlint runs with `--quiet` so only **errors** are reported. The `.oxlintrc.json` `suspicious` category is `warn`, so without `--quiet` those warnings print on every run (locally and in CI) as noise without ever failing the gate. `--quiet` keeps lint output focused on what actually blocks CI; the `correctness=error` gate is unchanged.

`lint:fix` / `format` are unchanged.

## Verification

`pnpm lint` runs clean (oxlint `--quiet` + `oxfmt --check`).

ref [GVA-795](https://linear.app/ghost/issue/GVA-795/clean-repos-deploy)
