### PR TITLE
Run tests before a version bump (preversion hook)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,12 @@ pnpm test:e2e             # full deploy against throwaway Docker containers
 
 ## Publishing
 
-`pnpm ship` runs the tests then `pnpm publish && git push --follow-tags`. Unlike
-the old `yarn publish`, `pnpm publish` does **not** bump the version — run
-`pnpm version <patch|minor|major>` first (it writes the tag), then `pnpm ship`.
+`pnpm publish` does **not** choose the version (unlike the old `yarn publish`),
+so a release is two steps: **`pnpm version <patch|minor|major>`** (or an exact
+version) then **`pnpm ship`** — the bump type is the only thing that changes
+between patch/minor/major releases. `pnpm version` runs `pnpm test` via the
+`preversion` hook and **aborts the bump if tests fail** (no stranded version
+commit/tag); on success it bumps `package.json`, commits, and tags `vX.Y.Z`.
+`pnpm ship` then builds, `pnpm publish`es `dist/`, and `git push --follow-tags`
+pushes the commit + tag to `main` — allowed by the Ghost Foundation ruleset
+bypass (`always`).

--- a/README.md
+++ b/README.md
@@ -158,9 +158,20 @@ CommonJS in `dist/`, which is what gets published.
 - `pnpm lint:fix` autofixes lint issues and reformats
 - `pnpm test` runs lint, type-check, and the unit suite
 
-### Publish
+### Releasing
 
-- `pnpm ship` (builds via `prepublishOnly`, then publishes `dist/`)
+Pick the version bump and ship — same two commands for every release type:
+
+```sh
+pnpm version <patch|minor|major>   # or an exact version, e.g. pnpm version 1.2.3
+pnpm ship
+```
+
+- `pnpm version` runs the full test suite first (via the `preversion` hook) and
+  **aborts the bump if it fails**, so a broken build never cuts a version. On
+  success it updates `package.json`, commits, and tags `vX.Y.Z`.
+- `pnpm ship` builds (`prepublishOnly`), publishes `dist/`, and pushes the
+  version commit + tag to `main` with `git push --follow-tags`.
 
 # Copyright & License
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:unit": "vitest run --coverage",
     "test": "pnpm lint && pnpm typecheck && pnpm test:unit",
     "test:e2e": "docker compose -f test/e2e/docker-compose.yml up --build --abort-on-container-exit --exit-code-from runner",
+    "preversion": "pnpm test",
     "prepublishOnly": "pnpm build",
     "preship": "pnpm test",
     "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then pnpm publish && git push --follow-tags; fi"


### PR DESCRIPTION
## What

Adds a `preversion` hook so the release flow runs the test suite **before** cutting a version:

```diff
+ "preversion": "pnpm test",
  "prepublishOnly": "pnpm build",
  "preship": "pnpm test",
```

Plus README/AGENTS docs for the release flow.

## Why

`pnpm publish` doesn't choose the version (unlike classic `yarn publish`), so a release is two steps — `pnpm version <bump>` then `pnpm ship`. Without a guard, `pnpm version <bump>` bumps + commits + tags immediately; if the build were broken you'd have a stranded version commit/tag to unwind. `pnpm version` runs `preversion` first and **aborts the bump when it exits non-zero** (verified), so `preversion: pnpm test` makes a green build a precondition for any version.

## Same flow for patch / minor / major

The bump type is just the argument — `preversion` runs for all of them:

```sh
pnpm version <patch|minor|major>   # or an exact version, e.g. pnpm version 1.2.3
pnpm ship
```

(Verified: `patch`→`vX.Y.Z+1`, `minor`→`vX.Y+1.0`, `major`→`vX+1.0.0`, and a failing `preversion` produces no bump/tag.)

`pnpm ship` then builds (`prepublishOnly`), publishes `dist/`, and `git push --follow-tags` pushes the version commit + tag to `main` — now permitted by the Ghost Foundation ruleset bypass (`always`).

ref [GVA-795](https://linear.app/ghost/issue/GVA-795/clean-repos-deploy)
