### PR TITLE
Keep pnpm updates on 10.x

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,3 +1,10 @@
 {
     extends: ['local>TryGhost/renovate-config'],
+    packageRules: [
+        {
+            description: 'Keep pnpm on 10.x while this repo supports Node 20.20.0; pnpm 11 requires Node 22.13 or newer.',
+            matchPackageNames: ['pnpm'],
+            allowedVersions: '<11',
+        },
+    ],
 }


### PR DESCRIPTION
## Summary

- Added a Renovate package rule that keeps `pnpm` updates below 11.
- Documented the constraint in the rule description: this repo still supports Node 20.20.0, while pnpm 11 requires Node 22.13 or newer.

## Validation

- `pnpm lint`