### PR TITLE
Pin Renovate updates for Node runtime jobs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,5 +6,12 @@
             matchPackageNames: ['pnpm'],
             allowedVersions: '<11',
         },
+        {
+            description: 'Keep CI runtime jobs pinned to Node 20.20.0; this is the lowest consumer runtime and must not drift to patch releases.',
+            matchManagers: ['github-actions'],
+            matchPackageNames: ['node'],
+            matchCurrentValue: '20.20.0',
+            allowedVersions: '20.20.0',
+        },
     ],
 }


### PR DESCRIPTION
## Summary

- Added a Renovate package rule for GitHub Actions `node` dependencies with the raw value `20.20.0`.
- Pins those runtime-floor CI jobs to `20.20.0` so Renovate does not reopen patch updates like `20.20.0` to `20.20.2`.
- Leaves the separate Node 22 and 24 compatibility jobs untouched.

## Validation

- `pnpm lint`