### PR TITLE
Added OIDC trusted publishing to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,73 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Preview what would be published without actually publishing'
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+
+    permissions:
+      # OIDC trusted publishing to npm. Provenance is enabled because this
+      # repository is public; public repos can generate a provenance
+      # attestation at publish time.
+      id-token: write
+      contents: read
+
+    env:
+      FORCE_COLOR: 1
+      CI: true
+      NPM_CONFIG_PROVENANCE: true
+      NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org'
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24.14.1'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Corepack
+        run: npm install --global corepack@0.34.6
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Determine whether to publish
+        id: pub
+        run: |
+          name=$(jq -r .name package.json)
+          version=$(jq -r .version package.json)
+          if [ -n "$(npm view "$name@$version" version 2>/dev/null)" ]; then
+            echo "$name@$version is already published; nothing to do"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "queueing $name@$version"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.pub.outputs.publish == 'true'
+        # --no-git-checks is required because actions/checkout leaves the repo on
+        # a detached HEAD, which pnpm's default publish branch check rejects.
+        run: pnpm publish --no-git-checks ${{ (github.event.inputs['dry-run'] == 'true' && '--dry-run') || '' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,12 +61,20 @@ pnpm test:e2e             # full deploy against throwaway Docker containers
 
 ## Publishing
 
-`pnpm publish` does **not** choose the version (unlike the old `yarn publish`),
-so a release is two steps: **`pnpm version <patch|minor|major>`** (or an exact
-version) then **`pnpm ship`** — the bump type is the only thing that changes
-between patch/minor/major releases. `pnpm version` runs `pnpm test` via the
-`preversion` hook and **aborts the bump if tests fail** (no stranded version
-commit/tag); on success it bumps `package.json`, commits, and tags `vX.Y.Z`.
-`pnpm ship` then builds, `pnpm publish`es `dist/`, and `git push --follow-tags`
-pushes the commit + tag to `main` — allowed by the Ghost Foundation ruleset
-bypass (`always`).
+Releasing is one command: **`pnpm ship <patch|minor|major>`** (or an exact
+version, or no argument for the interactive picker). `ship` is
+[`@tryghost/pro-ship`](https://www.npmjs.com/package/@tryghost/pro-ship); the
+`preship` hook runs `pnpm test` first and **aborts before any git mutation if
+tests fail** (no stranded version commit/tag). On success `pro-ship` bumps
+`package.json`, commits and tags `vX.Y.Z`, and `git push --follow-tags`es to
+`main` — allowed by the Ghost Foundation ruleset bypass (`always`). `ship` does
+**not** publish locally (no `--publish` flag) — see below.
+
+**Publishing runs in CI, not on your machine.** `.github/workflows/publish.yml`
+triggers on any push to `main` that changes `package.json` and publishes to npm
+via **OIDC trusted publishing** — no npm token is stored. The pushed release
+commit is what fires it; the workflow skips (no-op) if that version is already
+on the registry, so non-release edits to `package.json` are safe. It runs
+`pnpm publish`, which builds `dist/` via `prepublishOnly` and ships only `dist`,
+with provenance attestation (public repo). A manual `workflow_dispatch` run is
+available and defaults to `--dry-run`.

--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
     "test:unit": "vitest run --coverage",
     "test": "pnpm lint && pnpm typecheck && pnpm test:unit",
     "test:e2e": "docker compose -f test/e2e/docker-compose.yml up --build --abort-on-container-exit --exit-code-from runner",
-    "preversion": "pnpm test",
     "prepublishOnly": "pnpm build",
     "preship": "pnpm test",
-    "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then pnpm publish && git push --follow-tags; fi"
+    "ship": "pro-ship"
   },
   "dependencies": {
     "shipit-cli": "5.3.0"
   },
   "devDependencies": {
+    "@tryghost/pro-ship": "1.1.5",
     "@types/node": "24.13.2",
     "@vitest/coverage-v8": "4.1.9",
     "oxfmt": "0.57.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: 5.3.0
         version: 5.3.0
     devDependencies:
+      '@tryghost/pro-ship':
+        specifier: 1.1.5
+        version: 1.1.5
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -427,6 +430,14 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@tryghost/pro-ship@1.1.5':
+    resolution: {integrity: sha512-gwd4ynAnEHkj6bx+tfkZCYaL+WlNHQQmCkAJn7Q2H0Uq+mG74i2wwxUWr+wTuyxjLg8KviMux5uwtkEQfzi1VA==}
+    engines: {node: '>=20.20.0'}
+    hasBin: true
+
+  '@tryghost/root-utils@2.3.1':
+    resolution: {integrity: sha512-1g0HskTTDJzn3CzcEWhd4aKtcmPm3IztD7cyfQQiG4QX+6gfpPOkYk7Y5gDOwTKAYtfor0nc8npSY90vvIj93A==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -544,6 +555,9 @@ packages:
   cache-base@1.0.1:
     resolution: {integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==}
     engines: {node: '>=0.10.0'}
+
+  caller@1.1.0:
+    resolution: {integrity: sha512-n+21IZC3j06YpCWaxmUy5AnVqhmCIM2bQtqQyy00HJlmStRt6kwDX5F9Z97pqwAB+G/tgSz6q/kUBbNyQzIubw==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -671,6 +685,9 @@ packages:
   fill-range@4.0.0:
     resolution: {integrity: sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==}
     engines: {node: '>=0.10.0'}
+
+  find-root@1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
   findup-sync@3.0.0:
     resolution: {integrity: sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==}
@@ -1622,6 +1639,16 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@tryghost/pro-ship@1.1.5':
+    dependencies:
+      '@tryghost/root-utils': 2.3.1
+      semver: 7.8.5
+
+  '@tryghost/root-utils@2.3.1':
+    dependencies:
+      caller: 1.1.0
+      find-root: 1.1.0
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -1769,6 +1796,8 @@ snapshots:
       union-value: 1.0.1
       unset-value: 1.0.0
 
+  caller@1.1.0: {}
+
   chai@6.2.2: {}
 
   chalk@2.4.2:
@@ -1894,6 +1923,8 @@ snapshots:
       is-number: 3.0.0
       repeat-string: 1.6.1
       to-regex-range: 2.1.1
+
+  find-root@1.1.0: {}
 
   findup-sync@3.0.0:
     dependencies:


### PR DESCRIPTION
Publishing now runs in CI via OIDC (no stored npm token). The local release command moves to @tryghost/pro-ship, which bumps/commits/tags/ pushes; the new Publish workflow fires on the package.json change on main and publishes dist/ to npm with provenance, skipping already-published versions. Mirrors the knex-migrator setup.