### PR TITLE
Fixed the Node pin rule so Renovate actually applies it

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,7 +9,7 @@
         {
             description: 'Keep CI runtime jobs pinned to Node 20.20.0; this is the lowest consumer runtime and must not drift to patch releases.',
             matchManagers: ['github-actions'],
-            matchPackageNames: ['node'],
+            matchDepNames: ['node'],
             matchCurrentValue: '20.20.0',
             allowedVersions: '20.20.0',
         },


### PR DESCRIPTION
## Problem

Renovate created #64, bumping the CI jobs from Node 20.20.0 to 24.18.0 even though `renovate.json5` has a rule pinning those legs to 20.20.0.

## Root cause

The pin rule used `matchPackageNames: ['node']`, but for `node-version:` entries the github-actions manager extracts the dependency with `depName: "node"` and `packageName: "actions/node-versions"` (visible in #64's update table, where the `uses-with` rows link to `actions/node-versions`). Renovate v41 removed the deprecated fallback where `matchPackageNames` also compared `depName`, so the rule — added after that removal — has never matched anything.

The [Dependency Dashboard](https://github.com/TryGhost/Deploy/issues/15) confirms it: the 20.20.0 deps still listed `Updates: 20.20.2, 24.18.0`, which `allowedVersions: '20.20.0'` would have filtered out if the rule applied. The 20.20.2 patch PR only stopped reappearing because #55 was closed manually, which blocks recreation.

## Fix

Use `matchDepNames: ['node']`, which targets the field Renovate actually populates with `node` for this dependency. Validated with `renovate-config-validator`.

Note: a node-24 PR for `.nvmrc` and publish.yml is still expected — the rule deliberately pins only the 20.20.0 CI legs. #64 should be closed once this merges so Renovate recreates the node-24 branch without touching the pinned legs.